### PR TITLE
Bump up react to v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
         "@types/chai": "^4.2.15",
         "@types/jest": "^26.0.20",
         "@types/node": "^12.0.0",
-        "@types/react": "^17.0.2",
-        "@types/react-dom": "^17.0.1",
+        "@types/react": "^18.0.17",
+        "@types/react-dom": "^18.0.6",
         "@types/sinon": "^9.0.10",
         "@typescript-eslint/eslint-plugin": "^4.15.2",
         "@typescript-eslint/parser": "^4.15.2",
@@ -79,7 +79,7 @@
         "marked": "^1.2.9",
         "prettier": "^2.2.1",
         "pretty-quick": "^3.1.0",
-        "react": "^17.0.1",
+        "react": "^18.2.0",
         "semantic-release": "^17.4.0",
         "sinon": "^9.2.4",
         "ts-jest": "^26.5.2",
@@ -92,6 +92,6 @@
         }
     },
     "peerDependencies": {
-        "react": ">= 16.8.0 < 18"
+        "react": ">= 16.8.0 < 19"
     }
 }


### PR DESCRIPTION
## Summary
There is an issue with using react v18 in external projects. Basically because the peer dependencies were set to < 18, so when you run `npm install` or `npm ci` without the `--legacy-peer-deps` flag, it throws an error.

In this PR I have updated versions of @types/react, @types/react-dom, and react dev dependencies to the latest. I have also changed the peer dependencies, so that you can use react v18 as well.